### PR TITLE
PR for 12-prioritize-leading-pcs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: l1rotation
 Title: Identify Loading Vectors under Sparsity in Factor Models
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: c(
     person("Simon", "Freyaldenhoven", , "simon.freyaldenhoven@phil.frb.org", role = c("aut", "cph")),
     person("Ryan", "Kobler", , "kobleary@gmail.com", role = c("aut", "cre"))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # l1rotation (development version)
 
+# l1rotation v1.0.2
+
+* Updates internal function collate_solutions() to align with paper resubmission (when fewer local minima are found than expected, emphasize supplementing with leading PCs)
+
 # l1rotation v1.0.1
 
 * Fixes citation and typos

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,3 @@
-# l1rotation (development version)
-
 # l1rotation v1.0.2
 
 * Updates internal function collate_solutions() to align with paper resubmission (when fewer local minima are found than expected, emphasize supplementing with leading PCs)

--- a/R/collate_solutions.R
+++ b/R/collate_solutions.R
@@ -185,7 +185,7 @@ fill_with_pc <- function(consolidated_mins, initial_loadings, X, factorno){
       temp <- cbind(rotated_loadings, initial_loadings[, ell])
       min_eig[ell] <- min(eigen(t(temp) %*% temp)$values)
     }
-    index <- which.max(min_eig * sqrt(eig_x[1:factorno]))
+    index <- which.max(min_eig * eig_x[1:factorno])
     rotated_loadings <- cbind(rotated_loadings, initial_loadings[, index])
     R <- cbind(R, I[, index])
     message(paste("PC used:", index))

--- a/README.Rmd
+++ b/README.Rmd
@@ -57,6 +57,6 @@ lf$rotated_plot
 ## Citation
 
 Simon Freyaldenhoven. "Identification Through Sparsity in Factor Models: the l1-rotation criterion." [Philadelphia Fed Working Paper 20-25](https://doi.org/10.21799/frbp.wp.2020.25),
-February 2025.
+June 2025.
 
 Simon Freyaldenhoven, Ryan Kobler. "`l1rotation` package." Code and data repository at https://github.com/SimonFreyaldenhoven/l1rotation, March 2025.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ lf$rotated_plot
 
 Simon Freyaldenhoven. “Identification Through Sparsity in Factor Models:
 the l1-rotation criterion.” [Philadelphia Fed Working Paper
-20-25](https://doi.org/10.21799/frbp.wp.2020.25), February 2025.
+20-25](https://doi.org/10.21799/frbp.wp.2020.25), June 2025.
 
 Simon Freyaldenhoven, Ryan Kobler. “`l1rotation` package.” Code and data
 repository at <https://github.com/SimonFreyaldenhoven/l1rotation>, March


### PR DESCRIPTION
I checked out the other files from @SimonFreyaldenhoven's [pull request](https://github.com/SimonFreyaldenhoven/Factor_Rotation/pull/146/files/b33b7910fe8416cf1dbed4f90009cd64bf75f8ce#diff-dea9714f3e3d33c614806d4c71f4978c2888ab5e6c21f36c55df7f54ff19b93c) in Factor_Rotation and didn't see any changes other than this one (remove square root) to the code. As part of this I updated the news and description files and incremented the version number. 

Should be all set to merge. We can resubmit to CRAN now as well if you want. Just noting the citation is currently Philly WP from June. Then, once the paper is accepted or published (or if there are more edits) we should be able to submit again with updated cite/DOI too. 

